### PR TITLE
URLs with '?' need to be quoted/escaped with zsh+curl

### DIFF
--- a/install_dDocent_requirements
+++ b/install_dDocent_requirements
@@ -154,7 +154,7 @@ if which rainbow &>/dev/null; then
         	echo "Rainbow is already installed"
 	else
 		echo "Downloading and installing Rainbow"
-        	curl -L -o rainbow.x.tar.gz http://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files
+        	curl -L -o rainbow.x.tar.gz "http://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files"
         	tar xvzf rainbow.x.tar.gz
         	cd rainbow_*
         	make
@@ -164,7 +164,7 @@ if which rainbow &>/dev/null; then
 	fi
 else
 	echo "Downloading and installing Rainbow"
-	curl -L -o rainbow.x.tar.gz http://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files
+	curl -L -o rainbow.x.tar.gz "http://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files"
 	tar xvzf rainbow.x.tar.gz
 	cd rainbow_*
 	make
@@ -178,7 +178,7 @@ if which gnuplot &>/dev/null; then
 	echo "gnuplot is already installed"
 else
 	echo "Downliading and installing gnuplot"
-	curl -L -o gnuplot.x.tar.gz http://sourceforge.net/projects/gnuplot/files/latest/download?source=files
+	curl -L -o gnuplot.x.tar.gz "http://sourceforge.net/projects/gnuplot/files/latest/download?source=files"
 	tar xvzf gnuplot.x.tar.gz 
 	cd gnuplot-* 
 	current=`pwd` 


### PR DESCRIPTION
Hi Jon - ran into this today, thought I'd share.  Without quoting or escaping, you see messages like 

```
curl -L -o rainbow.x.tar.gz https://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files
zsh: no matches found: https://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files
```

By quoting, they download just fine:

```
$ curl -L -o rainbow.x.tar.gz "https://sourceforge.net/projects/bio-rainbow/files/latest/download?source=files"
######################################################################## 100.0%
```

Also, if it matters:

```
$ zsh --version
zsh 5.2 (x86_64-unknown-linux-gnu)
```

Cheers!
