### PR TITLE
Fixed python3.5 compatibility

### DIFF
--- a/scripts/dDocent_filters
+++ b/scripts/dDocent_filters
@@ -69,8 +69,8 @@ mawk '!/#/' $1 | cut -f1,2,6 > $1.loci.qual
 #Calculates the average depth and standard deviation
 DEPTH=$(mawk '{ sum += $1; n++ } END { if (n > 0) print sum / n; }' $1.DEPTH)
 SD=$(mawk '{delta = $1 - avg; avg += delta / NR; mean2 += delta * ($1 - avg); } END { print sqrt(mean2 / NR); }' $1.DEPTH)
-DEPTH=$(python -c "print int("$DEPTH") + int("$SD")")
-#DEPTH=$(python -c "print int("$DEPTH"+100*("$DEPTH"**0.5))")
+DEPTH=$(perl -e "print int("$DEPTH") + int("$SD")")
+#DEPTH=$(perl -e "print int("$DEPTH"+100*("$DEPTH"**0.5))")
 
 #Filters loci above the mean depth + 1 standard deviation that have quality scores that are less than 2*DEPTH
 paste $1.loci.qual $1.DEPTH | mawk -v x=$DEPTH '$4 > x'| mawk '$3 < 2 * $4' > $1.lowQDloci
@@ -127,9 +127,9 @@ EOF
 
 
 #Calculates a mean depth cutoff to use for filtering
-DP=$(python -c "print ($DP+ 1.645*$SD) / $IND")
+DP=$(perl -e "print ($DP+ 1.645*$SD) / $IND")
 PP=$(mawk '!/SUM/' $1.site.depth | sort -rn | perl -e '$d=.05;@l=<>;print $l[int($d*$#l)]' )
-PP=$(python -c "print int($PP / $IND)")
+PP=$(perl -e "print int($PP / $IND)")
 
 if [[ -z "$4" ]]; then
 echo "If distrubtion looks normal, a 1.645 sigma cutoff (~90% of the data) would be" $DP


### PR DESCRIPTION
The python commands in this script assume that python 2.7 is installed. The syntax is not compatible with python 3.5. Conveniently, the perl syntax is the same, so running the same commands with perl is a workaround.
