### PR TITLE
Fixed error when providing custom NEWCUTOFF

### DIFF
--- a/scripts/dDocent_filters
+++ b/scripts/dDocent_filters
@@ -80,7 +80,7 @@ echo -e "Number of sites filtered based on high depth and lower than 2*DEPTH qua
 echo -e "Number of sites filtered based on high depth and lower than 2*DEPTH quality score\n" $LQDL "of" $OLD "\n" >> $2.filterstats
 
 #Recalculates site depth for sites that have not been previously filtered
-vcftools --vcf $2.fil.vcf --remove-filtered NP --exclude-positions $1.lowQDloci --site-depth --out $1 > /dev/null
+vcftools --vcf $2.fil.vcf --remove-filtered NP --exclude-positions $1.lowQDloci --site-depth --out $1 2> /dev/null
 cut -f3 $1.ldepth > $1.site.depth
 
 DP=$(mawk '{ sum += $1; n++ } END { if (n > 0) print sum / n; }' $1.site.depth)
@@ -145,14 +145,14 @@ if [ "$NEWCUTOFF" != "yes" ]; then
 echo -e "Maximum mean depth cutoff is" $PP >> $2.filterstats
 
 #Combines all filters to create a final filtered VCF file
-vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --recode > /dev/null
+vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --recode 2> /dev/null
 FILTERED=$(mawk '!/#/' $2.FIL.recode.vcf  | wc -l)
 OLD=$(mawk '!/#/' $2.fil.vcf | wc -l)
 NUMFIL=$(($OLD - $FILTERED))
 echo -e "Number of sites filtered based on maximum mean depth\n" $NUMFIL "of" $OLD "\n"
 echo -e "Number of sites filtered based on maximum mean depth\n" $NUMFIL "of" $OLD "\n" >> $2.filterstats
 
-vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --exclude-positions $1.lowQDloci --recode > /dev/null
+vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --exclude-positions $1.lowQDloci --recode 2> /dev/null
 
 OLD=$(mawk '!/#/' $1 | wc -l)
 FILTERED=$(mawk '!/#/' $2.FIL.recode.vcf  | wc -l)
@@ -176,14 +176,15 @@ else
 	fi
 echo -e "Maximum mean depth cutoff is" $PP >> $2.filterstats
 #Combines all filters to create a final filtered VCF file
-vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --recode > /dev/null
+vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL --max-meanDP $PP --recode 2> /dev/null
 FILTERED=$(mawk '!/#/' $2.FIL.recode.vcf  | wc -l)
 OLD=$(mawk '!/#/' $2.fil.vcf | wc -l)
 NUMFIL=$(($OLD - $FILTERED))
 echo -e "Number of sites filtered based on maximum mean depth\n" $NUMFIL "of" $OLD "\n"
 echo -e "Number of sites filtered based on maximum mean depth\n" $NUMFIL "of" $OLD "\n" >> $2.filterstats
 
-vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL1 --max-meanDP $PP --exclude-positions $1.lowQDloci --recode --site-depth > /dev/null
+vcftools --vcf $2.fil.vcf --remove-filtered NP --recode-INFO-all --out $2.FIL1 --max-meanDP $PP --exclude-positions $1.lowQDloci --recode 2> /dev/null
+vcftools --vcf $2.FIL1.recode.vcf --site-depth --out $2.FIL1 2> /dev/null
 mawk '!/CHR/' $2.FIL1.ldepth | mawk '{
 if (NR == 1) {chrom=$1;i=1;pos[i]=$2;dp[i]=$3}
 else if ($1 == chrom) {i++;pos[i]=$2;dp[i]=$3}
@@ -195,7 +196,7 @@ DPMM=$(cat $2.dpmismatch.loci | wc -l)
 echo -e "Number of sites filtered based on within locus depth mismatch\n" $DPMM "of" $OLD "\n"
 echo -e "Number of sites filtered based on within locus depth mismatch\n" $DPMM "of" $OLD "\n" >> $2.filterstats
 
-vcftools --vcf $2.FIL1.recode.vcf --exclude-positions $2.dpmismatch.loci --recode --recode-INFO-all --out $2.FIL > /dev/null
+vcftools --vcf $2.FIL1.recode.vcf --exclude-positions $2.dpmismatch.loci --recode --recode-INFO-all --out $2.FIL 2> /dev/null
 
 OLD=$(mawk '!/#/' $1 | wc -l)
 FILTERED=$(mawk '!/#/' $2.FIL.recode.vcf  | wc -l)


### PR DESCRIPTION
Correcting an error with vcftools 0.1.15 which doesn't allow two outputs at once. That was an issue when running the script with  $NEWCUTOFF==yes (sorry, previously I tested it only with $NEWCUTOFF==no).

Also, the new vcftools print run information to stderr (changed > /dev/null to 2> /dev/null).