### PR TITLE
popmap creation logic

### DIFF
--- a/dDocent
+++ b/dDocent
@@ -3,7 +3,7 @@ export LC_ALL=en_US.UTF-8
 export SHELL=bash
 
 ##########dDocent##########
-VERSION='2.9.3'; export VERSION
+VERSION='2.9.4'; export VERSION
 #This script serves as an interactive bash wrapper to QC, assemble, map, and call SNPs from double digest RAD (SE or PE), ezRAD (SE or PE) data, or SE RAD data.
 #It requires that your raw data are split up by tagged individual and follow the naming convention of:
 

--- a/dDocent
+++ b/dDocent
@@ -516,7 +516,10 @@ if [ "$SNP" != "no" ]; then
 
 	# Creates a population file to use for more accurate genotype calling if one doesn't exist
 	if [ ! -f popmap ]; then
+		echo "popmap file not found, building a new one from the sample names"
 		cut -f1 -d "_" namelist | paste namelist - > popmap
+	else
+		echo "Using existing popmap file"
 	fi
 	
 	###New implementation of SNP calling here to save on memory	

--- a/dDocent
+++ b/dDocent
@@ -514,12 +514,11 @@ if [ "$SNP" != "no" ]; then
 	export FB2
 	echo -e "\nUsing FreeBayes to call SNPs"
 
-	#Creates a population file to use for more accurate genotype calling
+	# Creates a population file to use for more accurate genotype calling if one doesn't exist
+	if [ -f popmap ]; then
+		cut -f1 -d "_" namelist | paste namelist - > popmap
+	fi
 	
-	cut -f1 -d "_" namelist > p
-	paste namelist p > popmap
-	rm p
-
 	###New implementation of SNP calling here to save on memory	
 	call_genos(){
 		echo "Starting Freebayes instance " $1 >> freebayes.log

--- a/dDocent
+++ b/dDocent
@@ -515,7 +515,7 @@ if [ "$SNP" != "no" ]; then
 	echo -e "\nUsing FreeBayes to call SNPs"
 
 	# Creates a population file to use for more accurate genotype calling if one doesn't exist
-	if [ -f popmap ]; then
+	if [ ! -f popmap ]; then
 		cut -f1 -d "_" namelist | paste namelist - > popmap
 	fi
 	


### PR DESCRIPTION
This change does two things: 
1. only creates the `popmap` file if one isn't already present
2. makes the creation of the `popmap` file simpler

Respecting a detected `popmap` file means that a user can use manually-edited population definitions irrespective of the naming convention. Of course it would be best to have the filenames reflect the associated population, but this might not always be the case (localities or other non-genetic-population distinctions).